### PR TITLE
Refactor matching-service

### DIFF
--- a/apps/matching-service/controller/controller.ts
+++ b/apps/matching-service/controller/controller.ts
@@ -1,0 +1,40 @@
+import { Socket, Server } from 'socket.io';
+import { DefaultEventsMap } from 'socket.io/dist/typed-events';
+import { findMatchingUserInQueue, addUserToQueue, removeUserFromQueue } from '../model/repository';
+
+const respond = (
+  io: Server<DefaultEventsMap, DefaultEventsMap, DefaultEventsMap, any>,
+  socket: Socket
+) => {
+  // Client emits this event on clicking "Match" button.
+  // If there is another user queueing for the same difficulty then they are matched and
+  // the matched user is then removed from the QueueingUser table.
+  // Otherwise adds the client to the QueueingUser table.
+  socket.on('find-match', async (data) => {
+    // TypeScript support for Sequelize damn painful
+    const matchingUser: any = await findMatchingUserInQueue(data.difficulty, socket.id);
+    if (matchingUser !== null) {
+      const concatenatedIds = `${socket.id}%${matchingUser.socketId}`;
+      io.to(matchingUser.socketId).emit('match-found', concatenatedIds);
+      io.to(socket.id).emit('match-found', concatenatedIds);
+
+      // Only the user that was found is in DB
+      matchingUser.destroy();
+    } else {
+      addUserToQueue(data.difficulty, socket.id);
+    }
+  });
+
+  // Delete the queueing user
+  socket.on('cancel-match', async () => {
+    removeUserFromQueue(socket.id);
+  });
+
+  // Delete the queueing user if no match found and emit a new event for frontend to handle
+  socket.on('no-match-found', async () => {
+    removeUserFromQueue(socket.id);
+    io.to(socket.id).emit('server-no-match-found');
+  });
+};
+
+export default respond;

--- a/apps/matching-service/index.ts
+++ b/apps/matching-service/index.ts
@@ -1,7 +1,7 @@
 import express from 'express';
 import { createServer } from 'http';
 import { Server } from 'socket.io';
-import { Sequelize, DataTypes, Op } from 'sequelize';
+import respond from './controller/controller';
 
 const app = express();
 app.use(express.urlencoded({ extended: true }));
@@ -16,74 +16,8 @@ const io = new Server(httpServer, {
   }
 });
 
-const sequelize = new Sequelize('sqlite::memory:');
-
-const QueueingUser = sequelize.define('QueueingUser', {
-  socketId: {
-    type: DataTypes.STRING,
-    allowNull: false
-  },
-  difficulty: {
-    type: DataTypes.ENUM('easy', 'medium', 'hard'),
-    allowNull: false
-  }
-});
-QueueingUser.sync();
-
-const MatchingPair = sequelize.define('MatchingPair', {
-  socketId1: {
-    type: DataTypes.STRING,
-    allowNull: false
-  },
-  socketId2: {
-    type: DataTypes.STRING,
-    allowNull: false
-  },
-  difficulty: {
-    type: DataTypes.ENUM('easy', 'medium', 'hard'),
-    allowNull: false
-  }
-});
-MatchingPair.sync();
-
 io.on('connection', (socket) => {
-  // Client emits this event on clicking "Match" button.
-  // If there is another user queueing for the same difficulty then they are matched and added to
-  // MatchingPair table. The matched user is then removed from the QueueingUser table.
-  // Otherwise adds the client to the QueueingUser table.
-  socket.on('find-match', async (data) => {
-    // TypeScript support for Sequelize isn't very good yet
-    const matchedUser: any = await QueueingUser.findOne({
-      where: { difficulty: data.difficulty, [Op.not]: { socketId: socket.id } }
-    });
-    if (matchedUser !== null) {
-      const concatenatedIds = `${socket.id}%${matchedUser.socketId}`;
-      io.to(matchedUser.socketId).emit('match-found', concatenatedIds);
-      io.to(socket.id).emit('match-found', concatenatedIds);
-
-      MatchingPair.create({
-        socketId1: socket.id,
-        socketId2: matchedUser.socketId,
-        difficulty: data.difficulty
-      });
-
-      // Only the matched user is in DB
-      matchedUser.destroy();
-    } else {
-      QueueingUser.create({ socketId: socket.id, difficulty: data.difficulty });
-    }
-  });
-
-  // Delete the queueing user
-  socket.on('cancel-match', async () => {
-    QueueingUser.destroy({ where: { socketId: socket.id } });
-  });
-
-  // Delete the queueing user if no match found and emit a new event for frontend to handle
-  socket.on('no-match-found', async () => {
-    QueueingUser.destroy({ where: { socketId: socket.id } });
-    io.to(socket.id).emit('server-no-match-found');
-  });
+  respond(io, socket);
 });
 
 httpServer.listen(8001);

--- a/apps/matching-service/model/queueing-user.ts
+++ b/apps/matching-service/model/queueing-user.ts
@@ -1,0 +1,16 @@
+import { Sequelize, DataTypes } from 'sequelize';
+
+const QueueingUser = (sequelize: Sequelize) => {
+  return sequelize.define('QueueingUser', {
+    socketId: {
+      type: DataTypes.STRING,
+      allowNull: false
+    },
+    difficulty: {
+      type: DataTypes.ENUM('easy', 'medium', 'hard'),
+      allowNull: false
+    }
+  });
+};
+
+export default QueueingUser;

--- a/apps/matching-service/model/repository.ts
+++ b/apps/matching-service/model/repository.ts
@@ -1,0 +1,23 @@
+import { Sequelize, Op } from 'sequelize';
+import QueueingUser from './queueing-user';
+
+const sequelize = new Sequelize('sqlite::memory');
+const queueingUser = QueueingUser(sequelize);
+sequelize.sync();
+
+type Difficulty = 'easy' | 'medium' | 'hard';
+
+export const addUserToQueue = async (difficulty: Difficulty, socketId: string) => {
+  queueingUser.create({ socketId, difficulty });
+};
+
+// Finds a user (that isn't the same user that called this method) queueing for the same difficulty
+export const findMatchingUserInQueue = async (difficulty: Difficulty, socketId: string) => {
+  return queueingUser.findOne({
+    where: { difficulty, [Op.not]: { socketId } }
+  });
+};
+
+export const removeUserFromQueue = async (socketId: string) => {
+  queueingUser.destroy({ where: { socketId } });
+};


### PR DESCRIPTION
- removed `MatchingPair` table (used to store the socket ids of the matched player pairs) bc yagni and stuff
- moved all the socket logic to controller
- create a separate file for sequelize schema
- added respository