### PR TITLE
Use UUID as roomId

### DIFF
--- a/apps/matching-service/controller/controller.ts
+++ b/apps/matching-service/controller/controller.ts
@@ -1,6 +1,7 @@
 import { Socket, Server } from 'socket.io';
 import { DefaultEventsMap } from 'socket.io/dist/typed-events';
 import { findMatchingUserInQueue, addUserToQueue, removeUserFromQueue } from '../model/repository';
+import { v4 as uuidv4 } from 'uuid';
 
 const respond = (
   io: Server<DefaultEventsMap, DefaultEventsMap, DefaultEventsMap, any>,
@@ -14,9 +15,9 @@ const respond = (
     // TypeScript support for Sequelize damn painful
     const matchingUser: any = await findMatchingUserInQueue(data.difficulty, socket.id);
     if (matchingUser !== null) {
-      const concatenatedIds = `${socket.id}%${matchingUser.socketId}`;
-      io.to(matchingUser.socketId).emit('match-found', concatenatedIds);
-      io.to(socket.id).emit('match-found', concatenatedIds);
+      const roomId = uuidv4();
+      io.to(matchingUser.socketId).emit('match-found', roomId);
+      io.to(socket.id).emit('match-found', roomId);
 
       // Only the user that was found is in DB
       matchingUser.destroy();

--- a/apps/matching-service/package-lock.json
+++ b/apps/matching-service/package-lock.json
@@ -19,6 +19,7 @@
       },
       "devDependencies": {
         "@types/express": "^4.17.13",
+        "@types/uuid": "^8.3.4",
         "concurrently": "^7.4.0",
         "nodemon": "^2.0.19"
       }
@@ -211,6 +212,12 @@
         "@types/mime": "*",
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/uuid": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.4.tgz",
+      "integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==",
+      "dev": true
     },
     "node_modules/@types/validator": {
       "version": "13.7.6",
@@ -3003,6 +3010,12 @@
         "@types/mime": "*",
         "@types/node": "*"
       }
+    },
+    "@types/uuid": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.4.tgz",
+      "integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==",
+      "dev": true
     },
     "@types/validator": {
       "version": "13.7.6",

--- a/apps/matching-service/package.json
+++ b/apps/matching-service/package.json
@@ -16,6 +16,7 @@
   "license": "ISC",
   "devDependencies": {
     "@types/express": "^4.17.13",
+    "@types/uuid": "^8.3.4",
     "concurrently": "^7.4.0",
     "nodemon": "^2.0.19"
   },


### PR DESCRIPTION
- currently `roomId` is generated by concatenating the socket ids of the 2 matched clients
- since random question is generated by hashing `roomId`, if the same 2 clients are matched multiple times, they will always get the same question
- fixed by using a real UUID which is generated every time they match (so the random index generated will be different even if the same 2 clients are matched multiple times)